### PR TITLE
libc++ fixes

### DIFF
--- a/sys-libs/libcxx/libcxx-9999.ebuild
+++ b/sys-libs/libcxx/libcxx-9999.ebuild
@@ -9,13 +9,13 @@ EGIT_REPO_URI="http://llvm.org/git/libcxx.git
 	https://github.com/llvm-mirror/libcxx.git"
 CMAKE_MIN_VERSION=3.4.3
 
-[ "${PV%9999}" != "${PV}" ] && SCM="git-r3" || SCM=""
+[[ ${PV} == 9999 ]] && SCM="git-r3" || SCM=""
 
 inherit ${SCM} cmake-multilib toolchain-funcs
 
 DESCRIPTION="New implementation of the C++ standard library, targeting C++11"
 HOMEPAGE="http://libcxx.llvm.org/"
-if [ "${PV%9999}" = "${PV}" ] ; then
+if [[ ${PV} != 9999 ]] ; then
 	SRC_URI="http://llvm.org/releases/${PV}/${P}.src.tar.xz"
 	S="${WORKDIR}/${P}.src"
 else
@@ -24,7 +24,7 @@ fi
 
 LICENSE="|| ( UoI-NCSA MIT )"
 SLOT="0"
-if [ "${PV%9999}" = "${PV}" ] ; then
+if [[ ${PV} != 9999 ]] ; then
 	KEYWORDS="~amd64 ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
 else
 	KEYWORDS=""

--- a/sys-libs/libcxx/libcxx-9999.ebuild
+++ b/sys-libs/libcxx/libcxx-9999.ebuild
@@ -77,7 +77,7 @@ multilib_src_configure() {
 
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
-		-DLIBCXX_LIBDIR_SUFFIX=${libdir#lib}
+		-DLLVM_LIBDIR_SUFFIX=${libdir#lib}
 		-DLIBCXX_ENABLE_SHARED=ON
 		-DLIBCXX_ENABLE_STATIC=$(usex static-libs)
 		-DLIBCXX_CXX_ABI=${cxxabi}

--- a/sys-libs/libcxx/libcxx-9999.ebuild
+++ b/sys-libs/libcxx/libcxx-9999.ebuild
@@ -4,8 +4,10 @@
 
 EAPI=6
 
+: ${CMAKE_MAKEFILE_GENERATOR:=ninja}
 EGIT_REPO_URI="http://llvm.org/git/libcxx.git
 	https://github.com/llvm-mirror/libcxx.git"
+CMAKE_MIN_VERSION=3.4.3
 
 [ "${PV%9999}" != "${PV}" ] && SCM="git-r3" || SCM=""
 


### PR DESCRIPTION
With this, the ebuild gets more consistency, cmake macros are now properly located and tests work.
